### PR TITLE
Bugfix Login: after login problem: don't restart login, just ask again

### DIFF
--- a/src/js/leaflet.storage.xhr.js
+++ b/src/js/leaflet.storage.xhr.js
@@ -256,8 +256,8 @@ L.Storage.Xhr = {
             L.Storage.Xhr.listen_form('login_form', {
                 'callback': function (data) {
                     if (data.html) {
-                        // Problem in the login
-                        self.login(data, args);
+                        // Problem in the login - ask again
+                        ask_for_login(data);
                     }
                     else {
                         proceed();


### PR DESCRIPTION
Before this commit, when the login failed, it started a completely new login process with invalid final 'data'. Now it will just render a new login window with the data from the ajax request, login data will stay the same.