### PR TITLE
In edit mode: Shift-Click on object toggles edit action

### DIFF
--- a/src/js/leaflet.storage.features.js
+++ b/src/js/leaflet.storage.features.js
@@ -287,11 +287,19 @@ L.Storage.FeatureMixin = {
         if(!this.map.editEnabled) {
             this.view(e.latlng);
         } else if (!this.isReadOnly()) {
-            new L.Toolbar.Popup(e.latlng, {
-                className: 'leaflet-inplace-toolbar',
-                anchor: this.getPopupToolbarAnchor(),
-                actions: this.getInplaceToolbarActions(e)
-            }).addTo(this.map, this, e.latlng);
+            if(e.originalEvent.shiftKey) {
+                if(this._toggleEditing)
+                    this._toggleEditing(e);
+                else
+                    this.edit(e);
+            }
+            else {
+                new L.Toolbar.Popup(e.latlng, {
+                    className: 'leaflet-inplace-toolbar',
+                    anchor: this.getPopupToolbarAnchor(),
+                    actions: this.getInplaceToolbarActions(e)
+                }).addTo(this.map, this, e.latlng);
+            }
         }
         L.DomEvent.stop(e);
     },


### PR DESCRIPTION
I found it rather annoying to always need to click on a features and than to click the edit symbol in the toolbar popup. With this change the edit action will be toggled when you shift-click on a feature (you need to enable edit mode first of course).