### PR TITLE
out-of-box support for Mapbox Studio layers

### DIFF
--- a/src/js/leaflet.storage.js
+++ b/src/js/leaflet.storage.js
@@ -408,6 +408,11 @@ L.Storage.Map.include({
     },
 
     createTileLayer: function (tilelayer) {
+        // out-of-box support for Mapbox Studio layers
+        if (tilelayer.url_template.indexOf('api.mapbox.com/styles') != -1) {
+		    tilelayer.tileSize = 512;  
+		    tilelayer.zoomOffset = -1;
+	    }
         return new L.TileLayer(tilelayer.url_template, tilelayer);
     },
 


### PR DESCRIPTION
In current uMap it's impossible to use custom Mapbox Studio layer due technical differences.

Mapbox Studio layers exposes only 512x512 tiles with -1 zoomOffset.

See https://www.mapbox.com/api-documentation/#retrieve-raster-tiles-from-styles