### PR TITLE
Two compatiable problem to fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "leaflet-fullscreen": "^1.0.1",
     "leaflet-hash": "^0.2.1",
     "leaflet-i18n": "0.2.0",
-    "leaflet-loading": "^0.1.18",
+    "leaflet-loading": "ebrelsford/Leaflet.loading",
     "leaflet-measurable": "umap-project/Leaflet.Measurable",
     "leaflet-minimap": "^3.3.1",
     "leaflet-toolbar": "Leaflet/Leaflet.toolbar",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "leaflet-fullscreen": "^1.0.1",
     "leaflet-hash": "^0.2.1",
     "leaflet-i18n": "0.2.0",
-    "leaflet-loading": "ebrelsford/Leaflet.loading",
+    "leaflet-loading": "^0.1.22",
     "leaflet-measurable": "umap-project/Leaflet.Measurable",
     "leaflet-minimap": "^3.3.1",
     "leaflet-toolbar": "Leaflet/Leaflet.toolbar",

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@
         <script src="../reqs/contextmenu/leaflet.contextmenu-src.js"></script>
         <script src="../reqs/loading/Control.Loading.js"></script>
         <script src="../reqs/markercluster/leaflet.markercluster-src.js"></script>
-        <script src="../reqs/label/leaflet.label-src.js"></script>
+        <script src="../reqs/label/leaflet.label.js"></script>
         <script src="../reqs/photon/leaflet.photon.js"></script>
         <script src="../reqs/heat/leaflet-heat.js"></script>
         <script src="../reqs/fullscreen/Leaflet.fullscreen.js"></script>


### PR DESCRIPTION
1. fix tilelayer loading problem on Leaflet.loading

The version of Leaflet.loading  in package.json was 0.1.18, which is not compatiable to leaflet.js rc1. I changed the version to 0.1.22, which is suitable to the new version leaflet.

2. fix test/index.html 'leaflet.label-src.js'=>'leaflet.label.js'

In the test/index.html, 'leaflet.label-src.js' is not existed, which can be replaced by 'leaflet.label.js'